### PR TITLE
add wazo-dev-wip-bullseye distribution

### DIFF
--- a/distributions
+++ b/distributions
@@ -158,3 +158,15 @@ Uploaders: uploaders
 Contents: .gz
 SignWith: 527FBC6A
 ValidFor: 50d
+
+Origin: Wazo
+Codename: wazo-dev-wip-bullseye
+Label: wazo-dev-wip-bullseye
+Architectures: amd64 source
+Components: main
+# Update: wazo-dev-buster
+Description: Wazo Development Bullseye Migration Version
+Uploaders: uploaders
+Contents: .gz
+SignWith: 527FBC6A
+ValidFor: 50d

--- a/incoming
+++ b/incoming
@@ -52,3 +52,9 @@ IncomingDir: incoming/wazo-rc-buster
 TempDir: /tmp
 Default: wazo-rc-buster
 Cleanup: on_deny on_error unused_buildinfo_files
+
+Name: wazo-dev-wip-bullseye
+IncomingDir: incoming/wazo-dev-wip-bullseye
+TempDir: /tmp
+Default: wazo-dev-wip-bullseye
+Cleanup: on_deny on_error unused_buildinfo_files


### PR DESCRIPTION
This version is only during the dev for migration to bullseye
note: according old commit, the distro must end by bullseye, because
build-tools package will take the last world of distro