### PR TITLE
remove kamailio-buster distrubition

### DIFF
--- a/distributions
+++ b/distributions
@@ -129,7 +129,7 @@ Codename: wazo-dev-buster
 Label: wazo-dev-buster
 Architectures: amd64 i386 source
 Components: main
-Update: kamailio-buster bullseye-partial buster-backports wazo-celery-buster
+Update: bullseye-partial buster-backports wazo-celery-buster
 Description: Wazo Development Version
 Uploaders: uploaders
 Contents: .gz

--- a/kamailio-buster.list
+++ b/kamailio-buster.list
@@ -1,1 +1,0 @@
-kamailio = 5.3.2+buster

--- a/updates
+++ b/updates
@@ -53,14 +53,6 @@ Architectures: i386 amd64 source
 VerifyRelease: 3CBBABEE+
 FilterSrcList: deinstall buster-backports.list
 
-Name: kamailio-buster
-Method: http://deb.kamailio.org/kamailio53
-Suite: buster
-Components: main
-Architectures: i386 amd64 source
-VerifyRelease: 508EA4C8
-FilterSrcList: deinstall kamailio-buster.list
-
 Name: wazo-dev-buster
 Method: http://mirror.wazo.community/debian
 Suite: wazo-dev-buster


### PR DESCRIPTION
why: not used anymore and we use other method to install it