### PR TITLE
remove wazo-celery-buster distro

### DIFF
--- a/distributions
+++ b/distributions
@@ -129,7 +129,7 @@ Codename: wazo-dev-buster
 Label: wazo-dev-buster
 Architectures: amd64 i386 source
 Components: main
-Update: bookworm-partial bullseye-partial buster-backports wazo-celery-buster
+Update: bookworm-partial bullseye-partial buster-backports
 Description: Wazo Development Version
 Uploaders: uploaders
 Contents: .gz
@@ -143,17 +143,6 @@ Architectures: amd64 i386 source
 Components: main
 Update: - wazo-dev-buster
 Description: Wazo Release Candidate Version
-Uploaders: uploaders
-Contents: .gz
-SignWith: 527FBC6A
-ValidFor: 50d
-
-Origin: Wazo
-Codename: wazo-celery-buster
-Label: wazo-celery-buster
-Architectures: amd64 i386 source
-Components: main
-Description: Backup to save celery packages. To be removed when Wazo uses Debian Bullseye.
 Uploaders: uploaders
 Contents: .gz
 SignWith: 527FBC6A

--- a/updates
+++ b/updates
@@ -85,13 +85,6 @@ Architectures: i386 amd64 source
 VerifyRelease: B7D453EC | 22F3D138
 FilterSrcList: deinstall bookworm-partial.list
 
-Name: wazo-celery-buster
-Method: http://mirror.wazo.community/debian
-Suite: wazo-celery-buster
-Components: main
-Architectures: i386 amd64 source
-VerifyRelease: blindtrust
-
 Name: wazo-dev-bullseye
 Method: http://mirror.wazo.community/debian
 Suite: wazo-dev-bullseye


### PR DESCRIPTION
why: this distributions was unused as date of the latest buster. So
removing, just make thing clearer