### PR TITLE
sync ssh-dev-pubkeys to xivo-dev-tools distro

### DIFF
--- a/cron/crontab
+++ b/cron/crontab
@@ -1,1 +1,2 @@
 * * * * * /usr/local/bin/reprepro-main --silent --silent --waitforlock 10 --noskipold update phoenix-stretch
+* * * * * /usr/local/bin/reprepro-main --silent --silent --waitforlock 10 --noskipold update xivo-dev-tools

--- a/distributions
+++ b/distributions
@@ -18,6 +18,7 @@ Description: Development Tools Repository
 Uploaders: uploaders
 Contents: .gz
 SignWith: 527FBC6A
+Update: wazo-dev-bullseye-partial-tools
 
 Origin: Wazo
 Codename: asterisk-rc

--- a/updates
+++ b/updates
@@ -98,3 +98,11 @@ Suite: wazo-rc-bullseye
 Components: main
 Architectures: amd64 source
 VerifyRelease: blindtrust
+
+Name: wazo-dev-bullseye-partial-tools
+Method: http://mirror.wazo.community/debian
+Suite: wazo-dev-bullseye
+Components: main
+Architectures: amd64 source
+VerifyRelease: blindtrust
+FilterSrcList: deinstall wazo-dev-bullseye-partial-tools.list

--- a/wazo-dev-bullseye-partial-tools.list
+++ b/wazo-dev-bullseye-partial-tools.list
@@ -1,0 +1,1 @@
+wazo-dev-ssh-pubkeys install


### PR DESCRIPTION
Before, it was the jenkins job that migrate package into both
distribution. But now that job has been migrated to Jenkinsfile, only
one distribution is uppdated (wazo-dev-bullseye).

@sduthil 
Open to discuss If you think that this logic should be inside the Jenkinsfile

Note: mirror is already synced now