### PR TITLE
add bullseye-backport distribution

### DIFF
--- a/bullseye-backports.list
+++ b/bullseye-backports.list
@@ -1,0 +1,2 @@
+jinja2 install
+markupsafe install

--- a/distributions
+++ b/distributions
@@ -166,7 +166,7 @@ Codename: wazo-dev-bullseye
 Label: wazo-dev-bullseye
 Architectures: amd64 source
 Components: main
-Update: bookworm-partial
+Update: bullseye-backports bookworm-partial
 Description: Wazo Development Version
 Uploaders: uploaders
 Contents: .gz

--- a/updates
+++ b/updates
@@ -83,6 +83,15 @@ Architectures: i386 amd64 source
 VerifyRelease: 0D6C9793+
 FilterSrcList: deinstall bullseye-partial.list
 
+Name: bullseye-backports
+Method: http://ftp.ca.debian.org/debian
+Suite: bullseye-backports
+Components: main
+Architectures: i386 amd64 source
+# FTP master keys. See https://ftp-master.debian.org/keys.html
+VerifyRelease: 386FA1D9 | 2643E131
+FilterSrcList: deinstall bullseye-backports.list
+
 Name: bookworm-partial
 Method: http://ftp.ca.debian.org/debian
 Suite: bookworm


### PR DESCRIPTION
to import jinja2/markupsafe to prepare bookworm migration