### PR TITLE
backport python3-autocommand

### DIFF
--- a/bookworm-partial.list
+++ b/bookworm-partial.list
@@ -1,2 +1,3 @@
+python-autocommand
 python-typing-extensions install
 stevedore install


### PR DESCRIPTION
this is a dependency to backport cherrypy in preparation for the Bookworm migration