### PR TITLE
backport python3-jaraco.context

### DIFF
--- a/bookworm-partial.list
+++ b/bookworm-partial.list
@@ -1,3 +1,4 @@
+jaraco.context install
 python-autocommand install
 python-typing-extensions install
 stevedore install


### PR DESCRIPTION
this is a dependency to backport cherrypy in preparation for the Bookworm migration