### PR TITLE
backport python3-jaraco.functools

### DIFF
--- a/bookworm-partial.list
+++ b/bookworm-partial.list
@@ -1,5 +1,6 @@
 jaraco.classes install
 jaraco.context install
 python-autocommand install
+python-jaraco.functools install
 python-typing-extensions install
 stevedore install


### PR DESCRIPTION
this is a dependency to backport cherrypy in preparation for the Bookworm migration