### PR TITLE
backport python3-jaraco.collections

### DIFF
--- a/bookworm-partial.list
+++ b/bookworm-partial.list
@@ -1,4 +1,5 @@
 jaraco.classes install
+jaraco.collections install
 jaraco.context install
 jaraco.text install
 python-autocommand install


### PR DESCRIPTION
this is a dependency to backport cherrypy in preparation for the Bookworm migration