### PR TITLE
backport python3-cheroot

### DIFF
--- a/bookworm-partial.list
+++ b/bookworm-partial.list
@@ -3,6 +3,7 @@ jaraco.collections install
 jaraco.context install
 jaraco.text install
 python-autocommand install
+python-cheroot install
 python-jaraco.functools install
 python-typing-extensions install
 stevedore install


### PR DESCRIPTION
this is a dependency to backport cherrypy in preparation for the Bookworm migration