### PR TITLE
WAZO-4142-remove-xivo-dev-tools

### DIFF
--- a/cron/crontab
+++ b/cron/crontab
@@ -1,3 +1,2 @@
 * * * * * /usr/local/bin/reprepro-main --silent --silent --waitforlock 10 --noskipold update phoenix-stretch
-* * * * * /usr/local/bin/reprepro-main --silent --silent --waitforlock 10 --noskipold update xivo-dev-tools
 * * * * * /usr/local/bin/reprepro-main --silent --silent --waitforlock 10 --noskipold update wazo-dev-tools

--- a/distributions
+++ b/distributions
@@ -11,16 +11,6 @@ Contents: .gz
 SignWith: DFB0B268
 
 Origin: Wazo
-Codename: xivo-dev-tools
-Architectures: amd64 i386 source
-Components: main
-Description: Development Tools Repository
-Uploaders: uploaders
-Contents: .gz
-SignWith: 527FBC6A
-Update: wazo-dev-bullseye-partial-tools
-
-Origin: Wazo
 Codename: wazo-dev-tools
 Architectures: amd64 source
 Components: main

--- a/incoming
+++ b/incoming
@@ -1,10 +1,3 @@
-Name: xivo-dev-tools
-IncomingDir: incoming/xivo-dev-tools
-TempDir: /tmp
-Allow: xivo-dev-tools
-Default: xivo-dev-tools
-Cleanup: on_deny on_error unused_buildinfo_files
-
 Name: wazo-dev-tools
 IncomingDir: incoming/wazo-dev-tools
 TempDir: /tmp


### PR DESCRIPTION
POST-MERGE:
* `reprepro --delete clearvanished`
* `rm -r dists/xivo-dev-tools`
* `rm -r incoming/xivo-dev-tools`
* Confirm in the PR that post-merge actions have been done
